### PR TITLE
Fix/login data

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -9,8 +9,11 @@ export default function Dashboard(props) {
     const { jwt } = useContext(LoginContext)
     const localJwt = localStorage.currentUserJwt
     const [userData, setUserData] = useState({})
-    const [userIdeas, setUserIdeas] = useState([])
     const [userLoggedIn, setUserLoggedIn] = useState(true)
+
+
+    // not in use yet
+    // const [userIdeas, setUserIdeas] = useState([])
 
     useEffect(() => {
         if (jwt || localJwt)
@@ -57,8 +60,6 @@ export default function Dashboard(props) {
     if (!userData.firstName) return (
         <div>Fetching user data...
         <h3> If you keep seeing this, you probably are not <Link to="/login">logged in</Link> yet.</h3 >
-        
         </div>
     )
-
 }

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,22 +1,23 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import request from 'superagent';
 import { baseUrl } from '../../constants'
-import { Redirect } from 'react-router-dom'
+import { Redirect, Link } from 'react-router-dom'
+import { LoginContext } from '../Login/LoginContext';
 
 export default function Dashboard(props) {
-    const jwt = localStorage.currentUserJwt
+
+    const { jwt } = useContext(LoginContext)
+    const localJwt = localStorage.currentUserJwt
     const [userData, setUserData] = useState({})
     const [userIdeas, setUserIdeas] = useState([])
     const [userLoggedIn, setUserLoggedIn] = useState(true)
 
-
-
-    // look into useContext instead
     useEffect(() => {
-        request
-            .get(`${baseUrl}/current`)
-            .set("Authorization", `Bearer ${jwt}`)
-            .then(res => setUserData(res.body))
+        if (jwt || localJwt)
+            request
+                .get(`${baseUrl}/current`)
+                .set("Authorization", `Bearer ${jwt || localJwt}`)
+                .then(res => setUserData(res.body))
     }, [])
 
 
@@ -35,22 +36,28 @@ export default function Dashboard(props) {
     if (userLoggedIn === false)
         return (
             <Redirect to="/login" />)
+    if (userData.firstName)
+        return (
+            <div>
 
-    return (
-        <div>
+                <h4>This is {userData.firstName}'s dashboard</h4>
+                <button onClick={userLogout}>Log out</button>
+                <h3>Edit my profile</h3>
+                <h1>Dashboard</h1>
+                <ul>
+                    <li>Sample</li>
+                    <li>Data</li>
+                    <li>With</li>
+                    <li>Idea</li>
+                    <li>Links</li>
+                </ul>
 
-            <h4>This is {userData.firstName}'s dashboard</h4>
-            <button onClick={userLogout}>Log out</button>
-            <h3>Edit my profile</h3>
-            <h1>Dashboard</h1>
-            <ul>
-                <li>Sample</li>
-                <li>Data</li>
-                <li>With</li>
-                <li>Idea</li>
-                <li>Links</li>
-            </ul>
-
+            </div>
+        )
+    if (!userData.firstName) return (
+        <div>Fetching user data...
+        <h3> If you keep seeing this, you probably are not <Link to="/login">logged in</Link> yet.</h3 >
+        
         </div>
     )
 

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -4,12 +4,14 @@ import logo from '../../res/logo_horizontal_white.png';
 import { jsx } from '@emotion/core';
 import { baseUrl } from '../../constants'
 import request from 'superagent'
-import {Redirect} from 'react-router-dom'
+import { Redirect } from 'react-router-dom'
+import { LoginContext } from './LoginContext';
 
 export default function Login(props) {
 
   const [loginState, setLoginState] = useState({});
   const [userLoggedIn, setUserLoggedIn] = useState(false)
+  const [jwt, setJwt] = useState({})
 
 
   const handleSubmit = (e) => {
@@ -34,8 +36,9 @@ export default function Login(props) {
       .send({ email, password })
       .then(res => {
         if (res.status === 200) {
-          setUserLoggedIn(true)
           storeLocally(res.body.jwt)
+          setJwt(res.body.jwt)
+          setUserLoggedIn(true)
         }
       })
       .catch(err => {
@@ -78,8 +81,10 @@ export default function Login(props) {
         </form>
       </RightSide>
     </Container>);
-  if (userLoggedIn === true) return(
-    <Redirect to="/dashboard" />
+  if (userLoggedIn === true) return (
+    <LoginContext.Provider value={{jwt}}>
+      <Redirect to="/dashboard" />
+    </LoginContext.Provider>
   )
 }
 

--- a/src/components/Login/LoginContext.js
+++ b/src/components/Login/LoginContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const LoginContext = createContext({})


### PR DESCRIPTION
# In this pull request

* Fixed an issue where dashboard attempted to load user data before user JWT was passed on.

* Now uses a stateful or a local JWT, depending on what is available. This allows the correct data to be loaded both when dashboard is refreshed, or when dashboard is rendered through login redirect